### PR TITLE
Fix jm_rmdir for paths that contain whitespaces

### DIFF
--- a/FMIL/src/Util/src/JM/jm_portability.c
+++ b/FMIL/src/Util/src/JM/jm_portability.c
@@ -165,9 +165,9 @@ jm_status_enu_t jm_mkdir(jm_callbacks* cb, const char* dir) {
 
 jm_status_enu_t jm_rmdir(jm_callbacks* cb, const char* dir) {
 #ifdef WIN32
-	const char* fmt_cmd = "rmdir /s /q %s";
+	const char* fmt_cmd = "rmdir /s /q \"%s\"";
 #else
-    const char* fmt_cmd = "rm -rf %s";
+    const char* fmt_cmd = "rm -rf \"%s\"";
 #endif
     char * buf = (char*)cb->calloc(sizeof(char), strlen(dir)+strlen(fmt_cmd)+1);
 	if(!cb) {


### PR DESCRIPTION
This fix has also been reported to jmodelica.org:
  http://www.jmodelica.org/patch/27889